### PR TITLE
Updating dependabot-approve-merge.yml workflow from template

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -12,10 +12,20 @@ on:
       - master
       - stable*
 
+permissions:
+  contents: read
+
+concurrency: 
+  group: dependabot-approve-merge-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   auto-approve-merge:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      # for hmarr/auto-approve-action to approve PRs
+      pull-requests: write 
 
     steps:
       # Github actions bot approve


### PR DESCRIPTION
Automated update of the dependabot-approve-merge.yml workflow from https://github.com/nextcloud/.github