### PR TITLE
fix(ci): stick to github runners for oci test

### DIFF
--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   phpunit-oci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
They still fail on garm runners.
ubuntu-22.04 is only run on github runners.

Example of a failure on garm:
https://github.com/nextcloud/data_request/actions/runs/6070653587/job/16467130046