### PR TITLE
chore(CI): Updating dependabot-approve-merge.yml workflow from template

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -31,7 +31,13 @@ jobs:
       pull-requests: write
 
     steps:
-      # Github actions bot approve
+      - name: Disabled on forks
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          echo 'Can not approve PRs from forks'
+          exit 1
+
+      # GitHub actions bot approve
       - uses: hmarr/auto-approve-action@b40d6c9ed2fa10c9a2749eca7eb004418a705501 # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automated update of the dependabot-approve-merge.yml workflow from https://github.com/nextcloud/.github