### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -876,12 +876,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "01c4938b8b704cc5f3d4fa2ab1f5f9f609d8ce03"
+                "reference": "d1399b589aa6c0393b4f62bd7022315a711d8c09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/01c4938b8b704cc5f3d4fa2ab1f5f9f609d8ce03",
-                "reference": "01c4938b8b704cc5f3d4fa2ab1f5f9f609d8ce03",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d1399b589aa6c0393b4f62bd7022315a711d8c09",
+                "reference": "d1399b589aa6c0393b4f62bd7022315a711d8c09",
                 "shasum": ""
             },
             "require": {
@@ -912,7 +912,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-11-26T00:46:02+00:00"
+            "time": "2025-01-08T00:43:56+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency