### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<summary>Request your data from the admins</summary>
 	<description><![CDATA[Enable your users to request an export or deletion of their data. According options are added to the personal settings section. Administrators will be notified by email about the request.]]></description>
 	<version>5.2.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author mail="blizzz@arthur-schiwon.de" homepage="https://nextcloud.com">Arthur Schiwon</author>
 	<namespace>DataRequest</namespace>
 	<category>tools</category>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "nextcloud/data_request",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"config": {
 		"optimize-autoloader": true,
 		"classmap-authoritative": true,


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
